### PR TITLE
feat: support Unicode annotation title

### DIFF
--- a/pdfoutline.py
+++ b/pdfoutline.py
@@ -64,8 +64,8 @@ def elist_to_gs(elist):
     def rec_elist_to_gslist(elist):
         gs_list = []
         for entry in elist:
-            gs_list.append("[/Page %d /View [/XYZ null null null] /Title (%s) /Count %d /OUT pdfmark" \
-                    % (entry.page, entry.name, len(entry.children)))
+            gs_list.append("[/Page %d /View [/XYZ null null null] /Title <%s> /Count %d /OUT pdfmark" \
+                    % (entry.page, entry.name.encode("utf-16").hex(), len(entry.children)))
             gs_list += rec_elist_to_gslist(entry.children)
         return gs_list
 


### PR DESCRIPTION
Per `pdfmark` reference:

> The encoding and character set used is either PDFDocEncoding (as
described in Appendix D in the PDF Reference) or Unicode. If
Unicode, the string must begin with <FEFF>. For example, the string
“ABC” is represented as (ABC) in PDFDocEncoding and
<FEFF004100420043> in Unicode. Title has a maximum length of
255 PDFDocEncoding characters or 126 Unicode values, although a
practical limit of 32 characters is advised so that it can be read easily
in the Acrobat viewer.

This PR should also fix the issue that an unclosed parenthesis in annotation title name will fail the GS command.