### PR TITLE
Allow use of arbitrary indent styles

### DIFF
--- a/pdfoutline.py
+++ b/pdfoutline.py
@@ -23,15 +23,53 @@ class Entry():
             c.pritty_print(depth+1)
 
 
-def toc_to_elist(toc, TAB = '    '):
+# Parse the start of the line for whitespace characters and return "tab";
+# should only be called once on first occurrence of an indent while tab == ""
+def parse_tab(line):
+    tab = ""
 
+    # add whitespace characters to tab
+    for ch in line:
+        if (ch.isspace()):
+            tab += ch
+        else:
+            break
+
+    return tab
+
+
+def toc_to_elist(toc):
+
+    tab = "" # indentation character(s) evaluated and assigned to this later
     lines = toc.split('\n')
     cur_entry = [[]] # current entries by depth
     offset = 0
 
     for line in lines:
 
-        depth = line.count(TAB)
+        # if indentation style hasn't been evaluated yet and the line starts
+        # with a whitespace character, assume its an indent and assign all the
+        # leading whitespace to tab
+        if ((tab == "") and (line != "") and (line[0].isspace())):
+            tab = parse_tab(line)
+
+        depth = 0
+
+        # determine depth level of indent
+        if (tab != ""):
+            # find length of leading whitespace in string
+            ws_len = 0
+            for ch in line:
+                if (ch.isspace()):
+                    ws_len += 1
+                else:
+                    break
+
+            # count indent level up to first non-whitespace character;
+            # allows for "indents" to appear inside section titles e.g. if an
+            # indent level of a single space was chosen
+            depth = line.count(tab, 0, ws_len)
+
         line = line.split('#')[0].strip() # strip comments and white spaces
 
         if not line:


### PR DESCRIPTION
Recognizes different styles of indents e.g. a tab, 3 spaces, 207 spaces
with 15 tabs, etc. The first occurrence of whitespace at the start of the line
will trigger the code to define that collection of whitespace as an "indent."
This can break if a blank line has whitespace characters.

Also fixes the error where "indents" embedded inside the section title
would count towards the depth.