### PR TITLE
Fixes the encoding of the bookmark titles

### DIFF
--- a/pdfoutline.py
+++ b/pdfoutline.py
@@ -105,7 +105,7 @@ def elist_to_gs(elist):
         gs_list = []
         for entry in elist:
             gs_list.append("[/Page %d /View [/XYZ null null null] /Title <%s> /Count %d /OUT pdfmark" \
-                    % (entry.page, entry.name.encode("utf-16").hex(), len(entry.children)))
+                    % (entry.page, "FEFF" + entry.name.encode("utf-16-be").hex(), len(entry.children)))
             gs_list += rec_elist_to_gslist(entry.children)
         return gs_list
 


### PR DESCRIPTION
In the pdfMark reference: "If Unicode, the string must begin with `<FEFF>`. For example, the Unicode string for (ABC) is `<FEFF004100420043>`. Title has a maximum length of 255 PDFDocEncoding characters or 126 Unicode values, although a practical limit of 32 characters is advised so that it can be read easily in the Acrobat viewer" (https://opensource.adobe.com/dc-acrobat-sdk-docs/acrobatsdk/pdfs/acrobatsdk_pdfmark.pdf)